### PR TITLE
use https for pulling allure-commandline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir /allure-results
 RUN mkdir /allure-report
 RUN mkdir /allure-config
 
-RUN wget http://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/$VERSION/allure-commandline-$VERSION.tgz
+RUN wget https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/$VERSION/allure-commandline-$VERSION.tgz
 RUN tar -zxf allure-commandline-$VERSION.tgz
 RUN mv ./allure-$VERSION/* /allure/
 RUN rm allure-commandline-$VERSION.tgz


### PR DESCRIPTION
http is now returning 501 and https is mandatory, so it's a simple fix